### PR TITLE
fix(github-action)!: resolve command injection vulnerability in action script

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,15 @@ branding:
   color: orange
 
 inputs:
+
+  config_file:
+    description: |
+      Path to a custom semantic-release configuration file. By default, an empty
+      string will look for a pyproject.toml file in the current directory. This is the same
+      as passing the `-c` or `--config` parameter to semantic-release.
+    default: ""
+    required: false
+
   directory:
     description: |
       Sub-directory to change into before running semantic-release publish
@@ -20,18 +29,27 @@ inputs:
       edit releases.
     required: true
 
-  root_options:
+  no_operation_mode:
     description: |
-      Additional options for the root `semantic-release` command.
-      Example: -vv --noop
+      If set to true, the github action will pass the `--noop` parameter to
+      semantic-release. This will cause semantic-release to run in "no operation"
+      mode. See the documentation for more information on this parameter.
+    default: "false"
     required: false
-    default: "-v"
 
   tag:
     description: |
       The tag corresponding to the GitHub Release that the artifacts should
       be published to. Defaults to 'latest', in which case the latest tag
       will be identified by Python Semantic Release and used to publish to.
+    required: false
+
+  verbosity:
+    description: |
+      Set the verbosity level of the output as the number of -v's to pass to
+      semantic-release. 0 is no extra output, 1 is info level output, 2 is
+      debug output, and 3 is silly debug level of output.
+    default: "1"
     required: false
 
 runs:

--- a/src/action.sh
+++ b/src/action.sh
@@ -8,23 +8,87 @@ explicit_run_cmd() {
   eval "$cmd"
 }
 
+# Convert "true"/"false" into command line args, returns "" if not defined
+eval_boolean_action_input() {
+	local -r input_name="$1"
+	shift
+	local -r flag_value="$1"
+	shift
+	local -r if_true="$1"
+	shift
+	local -r if_false="$1"
+
+	if [ -z "$flag_value" ]; then
+		printf ""
+	elif [ "$flag_value" = "true" ]; then
+		printf '%s\n' "$if_true"
+	elif [ "$flag_value" = "false" ]; then
+		printf '%s\n' "$if_false"
+	else
+		printf 'Error: Invalid value for input %s: %s is not "true" or "false\n"' \
+			"$input_name" "$flag_value" >&2
+		return 1
+	fi
+}
+
+# Convert string input into command line args, returns "" if undefined
+eval_string_input() {
+	local -r input_name="$1"
+	shift
+	local -r if_defined="$1"
+	shift
+	local value
+	value="$(printf '%s' "$1" | tr -d ' ')"
+
+	if [ -z "$value" ]; then
+		printf ""
+		return 0
+	fi
+
+	printf '%s' "${if_defined/\%s/$value}"
+}
+
 # See https://github.com/actions/runner-images/issues/6775#issuecomment-1409268124
 # and https://github.com/actions/runner-images/issues/6775#issuecomment-1410270956
 git config --system --add safe.directory "*"
 
 # Change to configured directory
-cd "${INPUT_DIRECTORY}"
+cd "${INPUT_DIRECTORY}" || exit 1
 
 # Make Token available as a correctly-named environment variables
 export GH_TOKEN="${INPUT_GITHUB_TOKEN}"
 
-# Bash array to store publish arguments
-PUBLISH_ARGS=()
+# Bash array to store semantic release root options
+ROOT_OPTIONS=()
 
-# Add publish arguments as necessary
-if [ -n "${INPUT_TAG}" ]; then
-  PUBLISH_ARGS+=("--tag ${INPUT_TAG}")
+if ! printf '%s\n' "$INPUT_VERBOSITY" | grep -qE '^[0-9]+$'; then
+	printf "Error: Input 'verbosity' must be a positive integer\n" >&2
+	exit 1
 fi
 
+VERBOSITY_OPTIONS=""
+for ((i = 0; i < INPUT_VERBOSITY; i++)); do
+	[ "$i" -eq 0 ] && VERBOSITY_OPTIONS="-"
+	VERBOSITY_OPTIONS+="v"
+done
+
+ROOT_OPTIONS+=("$VERBOSITY_OPTIONS")
+
+if [ -n "$INPUT_CONFIG_FILE" ]; then
+	# Check if the file exists
+	if [ ! -f "$INPUT_CONFIG_FILE" ]; then
+		printf "Error: Input 'config_file' does not exist: %s\n" "$INPUT_CONFIG_FILE" >&2
+		exit 1
+	fi
+
+	ROOT_OPTIONS+=("$(eval_string_input "config_file" "--config %s" "$INPUT_CONFIG_FILE")") || exit 1
+fi
+
+ROOT_OPTIONS+=("$(eval_boolean_action_input "no_operation_mode" "$INPUT_NO_OPERATION_MODE" "--noop" "")") || exit 1
+
+# Bash array to store publish arguments
+PUBLISH_ARGS=()
+PUBLISH_ARGS+=("$(eval_string_input "tag" "--tag %s" "$INPUT_TAG")") || exit 1
+
 # Run Semantic Release
-explicit_run_cmd "$PSR_VENV_BIN/semantic-release ${INPUT_ROOT_OPTIONS} publish ${PUBLISH_ARGS[*]}"
+explicit_run_cmd "$PSR_VENV_BIN/semantic-release ${ROOT_OPTIONS[*]} publish ${PUBLISH_ARGS[*]}"

--- a/tests/example_project/releaserc.toml
+++ b/tests/example_project/releaserc.toml
@@ -1,0 +1,2 @@
+[semantic-release]
+commit_parser = "emoji"

--- a/tests/suite/test_publish_w_custom_config.sh
+++ b/tests/suite/test_publish_w_custom_config.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+__file__="$(realpath "${BASH_SOURCE[0]}")"
+__directory__="$(dirname "${__file__}")"
+
+if ! [ "${UTILS_LOADED}" = "true" ]; then
+    # shellcheck source=tests/utils.sh
+    source "$__directory__/../utils.sh"
+fi
+
+test_with_custom_config() {
+    # Using default configuration within PSR with no modifications
+    # triggering the NOOP mode to prevent errors since the repo doesn't exist
+    # We are just trying to test that the root options are passed to the action
+    # without a fatal error
+    local index="${1:?Index not provided}"
+    local test_name="${FUNCNAME[0]}"
+
+    # Create expectations & set env variables that will be passed in for Docker command
+    local WITH_VAR_GITHUB_TOKEN="ghp_1x2x3x4x5x6x7x8x9x0x1x2x3x4x5x6x7x8x9x0"
+    local WITH_VAR_NO_OPERATION_MODE="true"
+    local WITH_VAR_CONFIG_FILE="releaserc.toml"
+    local expected_psr_cmd=".*/bin/semantic-release -v --config releaserc.toml --noop publish"
+
+    # Execute the test & capture output
+    # Fatal errors if exit code is not 0
+    local output=""
+    if ! output="$(run_test "$index. $test_name" 2>&1)"; then
+        # Log the output for debugging purposes
+        log "$output"
+        error "fatal error occurred!"
+        error "::error:: $test_name failed!"
+        return 1
+    fi
+
+    # Evaluate the output to ensure the expected command is present
+    if ! printf '%s' "$output" | grep -q "$expected_psr_cmd"; then
+        # Log the output for debugging purposes
+        log "$output"
+        error "Failed to find the expected command in the output!"
+        error "\tExpected Command: $expected_psr_cmd"
+        error "::error:: $test_name failed!"
+        return 1
+    fi
+
+    log "\n$index. $test_name: PASSED!"
+}

--- a/tests/suite/test_publish_w_tag.sh
+++ b/tests/suite/test_publish_w_tag.sh
@@ -14,13 +14,14 @@ test_with_tag() {
     # We are just trying to test that the root options & tag arguments are
     # passed to the action without a fatal error
     local index="${1:?Index not provided}"
-    local test_name="Test with tag"
+    local test_name="${FUNCNAME[0]}"
 
     # Create expectations & set env variables that will be passed in for Docker command
     local WITH_VAR_GITHUB_TOKEN="ghp_1x2x3x4x5x6x7x8x9x0x1x2x3x4x5x6x7x8x9x0"
     local WITH_VAR_TAG="v1.0.0"
-    local WITH_VAR_ROOT_OPTIONS="--noop -vv"
-    local expected_psr_cmd=".*/bin/semantic-release $WITH_VAR_ROOT_OPTIONS publish --tag $WITH_VAR_TAG"
+    local WITH_VAR_NO_OPERATION_MODE="true"
+    local WITH_VAR_VERBOSITY="2"
+    local expected_psr_cmd=".*/bin/semantic-release -vv --noop publish --tag $WITH_VAR_TAG"
 
     # Execute the test & capture output
     # Fatal errors if exit code is not 0

--- a/tests/suite/test_publish_wo_tag.sh
+++ b/tests/suite/test_publish_wo_tag.sh
@@ -14,12 +14,13 @@ test_without_tag() {
     # We are just trying to test that the root options are passed to the action
     # without a fatal error
     local index="${1:?Index not provided}"
-    local test_name="Test without tag"
+    local test_name="${FUNCNAME[0]}"
 
     # Create expectations & set env variables that will be passed in for Docker command
     local WITH_VAR_GITHUB_TOKEN="ghp_1x2x3x4x5x6x7x8x9x0x1x2x3x4x5x6x7x8x9x0"
-    local WITH_VAR_ROOT_OPTIONS="--noop -vv"
-    local expected_psr_cmd=".*/bin/semantic-release $WITH_VAR_ROOT_OPTIONS publish"
+    local WITH_VAR_NO_OPERATION_MODE="true"
+    local WITH_VAR_VERBOSITY="1"
+    local expected_psr_cmd=".*/bin/semantic-release -v --noop publish"
 
     # Execute the test & capture output
     # Fatal errors if exit code is not 0

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -22,11 +22,15 @@ explicit_run_cmd() {
 }
 
 run_test() {
-    local test_name="$1"
+    local test_name="${1:?Test name not provided}"
+    test_name="${test_name//_/ }"
+    test_name="$(tr "[:lower:]" "[:upper:]" <<< "${test_name:0:1}")${test_name:1}"
 
     # Set Defaults based on action.yml
     [ -z "$WITH_VAR_DIRECTORY" ] && local WITH_VAR_DIRECTORY="."
-    [ -z "$WITH_VAR_ROOT_OPTIONS" ] && local WITH_VAR_ROOT_OPTIONS="-v"
+    [ -z "$WITH_VAR_CONFIG_FILE" ] && local WITH_VAR_CONFIG_FILE=""
+    [ -z "$WITH_VAR_NO_OPERATION_MODE" ] && local WITH_VAR_NO_OPERATION_MODE="false"
+    [ -z "$WITH_VAR_VERBOSITY" ] && local WITH_VAR_VERBOSITY="1"
 
     # Extract all WITH_VAR_ variables dynamically from environment
     local ENV_ARGS=()


### PR DESCRIPTION
<!--
Please do not combine multiple features or fix actions that are not
directly dependent on one another. Please open multiple PRs instead because
one may be merged while the other is denied or has requested changes. This
will slow down the process of merging the accepted changes as reviews are
also more difficult to evaluate for edge cases.
-->

## Purpose
<!-- Reason for the PR (solves an issue/problem, adds a feature, etc) -->

- Resolves: #55

## Rationale
<!--
How did you come to this conclusion as the solution? What was your
reasoning? What were you trying to do? What problems did you find and avoid?
-->

Prevents the malicious execution of arbitrary code when a command injection is defined in the action yaml as part of the action parameter specification. Low impact exploitation if proper least privilege is implemented and pull request code is reviewed before merging to a release branch.

Includes a breaking change as the `root_options` action input parameter has been removed because it created a command injection vulnerability for arbitrary code to execute within the container context of the GitHub action if a command injection code was provided as part of the `root_options` parameter string. To eliminate the vulnerability, each relevant option that can be provided to `semantic-release` has been individually added as its own parameter and will be processed individually to prevent command injection. Please review our [`Github Actions Configuration`](https://python-semantic-release.readthedocs.io/en/stable/configuration/automatic-releases/github-actions.html) page on the Python Semantic Release Documentation website to review the newly available configuration options that replace the `root_options` parameter.

## How did you test?
<!--
Please explain the methodology for how you verified this solution. It helps to
describe the primary case and the possible edge cases that you considered and
ultimately how you tested them. If you didn't rulled out any edge cases, please
mention the rationale here.
-->

Added an additional test to run the github action simulator with the new parameter `config_file`.
