### PR TITLE
Fix URL updated to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This GitHub Action runs `semantic-release publish` using
 [`python-semantic-release`](https://pypi.org/project/python-semantic-release/).
 
 Full usage information and examples for this GitHub Action is hosted on
-[Python Semantic Release - ReadTheDocs](https://python-semantic-release.readthedocs.io/en/latest/automatic-releases/github-actions.html)
+[Python Semantic Release - ReadTheDocs](https://python-semantic-release.readthedocs.io/en/stable/configuration/automatic-releases/github-actions.html#gh-actions-publish)
 website.
 
 > **WARNING**: This Action is intended to be used in conjunction with Python


### PR DESCRIPTION
## Purpose
URL updated to point to a valid URL



## Rationale
Tried to access the documentation and it wasn't working.



## How did you test?
Copied the URL from the browser.


## How to Verify
Try the old and new URL. 

Resolves: #66